### PR TITLE
Add `package.json` to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "Javascript module to extract and fetch HTTP link information from blocks of text.",
   "main": "build/index.js",
   "exports": {
-    "require": "./build/index.js",
-    "import": "./build/index.js"
+    ".": {
+      "require": "./build/index.js",
+      "import": "./build/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "types": "build/index.d.ts",
   "scripts": {


### PR DESCRIPTION
React Native expects this to be present, otherwise we get warnings when running the Metro bundler.